### PR TITLE
Add windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function mkdirp(dir, cb) {
 	}
 
 	var mkdir = function (dir) {
+		dir = dir.replace(/\\/g,'/');
 		this.raw.mkd(dir, function (err) {
 			if (err && err.code === 550) {
 				if (dirs.length > 0) {


### PR DESCRIPTION
This ensures we use forward slashes for the ftp path, even in windows environments.
