### PR TITLE
Add missing code to readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,10 @@ const JSFtp = require('jsftp');
 // decorate `JSFtp` with a new method `mkdirp`
 require('jsftp-mkdirp')(JSFtp);
 
+const ftp = new JSFtp({
+	host: 'myserver.com'
+});
+
 const path = 'public_html/deploy/foo/bar';
 
 ftp.mkdirp(path).then(() => {


### PR DESCRIPTION
If someone is familiar with jsftp's documentation, the example makes sense, but if you're not very familiar with it, then it might look like "ftp" is supposed to be "JSFtp".