### PR TITLE
Add test to do mkdirp on an existing path

### DIFF
--- a/test.js
+++ b/test.js
@@ -51,3 +51,7 @@ test.serial('create nested directories', async t => {
 	await ftp.mkdirp(testDir);
 	t.true(await pathExists(path.join(__dirname, testDir)));
 });
+
+test.serial('ok to mkdirp on directories that already exist', async t => {
+	t.notThrows(ftp.mkdirp(testDir));
+});


### PR DESCRIPTION
Add a (failing) test, asserting that it is OK to call `ftp.mkdirp(path)` on a path that already exists.