### PR TITLE
Check if the directory exists before trying to create it

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,12 +40,12 @@ function mkdirp(dir) {
 		return pify(this.raw.mlst.bind(this.raw))(dir)
 			.then(() => dirs.length > 0 && checkIfDirExists(dirs.pop()))
 			.catch(err => {
-				if (err.code !== 550 || dirs.length === 0) {
-					err.message += ` - mkd: ${dir}`;
-					throw err;
-				} else {
+				if (err.code === 550) {
 					return mkdir(dir);
 				}
+
+				err.message += ` - mkd: ${dir}`;
+				throw err;
 			});
 	};
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,22 @@ function mkdirp(dir) {
 			});
 	};
 
-	return mkdir(dirs.pop());
+	const checkIfDirExists = dir => {
+		dir = slash(dir);
+
+		return pify(this.raw.mlst.bind(this.raw))(dir)
+			.then(() => dirs.length > 0 && checkIfDirExists(dirs.pop()))
+			.catch(err => {
+				if (err.code !== 550 || dirs.length === 0) {
+					err.message += ` - mkd: ${dir}`;
+					throw err;
+				} else {
+					return mkdir(dir);
+				}
+			});
+	};
+
+	return checkIfDirExists(dirs.pop());
 }
 
 module.exports = JSFtp => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "pify": "^2.3.0",
     "slash": "^1.0.0"
   },
+  "peerDependencies": {
+    "jsftp": "^1.5.4",
+  },
   "devDependencies": {
     "ava": "*",
     "del": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "slash": "^1.0.0"
   },
   "peerDependencies": {
-    "jsftp": "^1.5.4",
+    "jsftp": "^1.5.4"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "del": "^2.2.0",
     "delay": "^1.3.1",
     "ftp-test-server": "0.0.2",
-    "jsftp": "^1.3.1",
+    "jsftp": "^1.5.4",
     "path-exists": "^2.0.0",
     "xo": "*"
   },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "path-exists": "^2.0.0",
     "xo": "*"
   },
+  "peerDependencies": {
+    "jsftp": "^1.5.4"
+  },
   "xo": {
     "esnext": true
   }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "pify": "^2.3.0",
     "slash": "^1.0.0"
   },
-  "peerDependencies": {
-    "jsftp": "^1.5.4"
-  },
   "devDependencies": {
     "ava": "*",
     "del": "^2.2.0",

--- a/test.js
+++ b/test.js
@@ -51,3 +51,7 @@ test.serial('create nested directories', async t => {
 	await ftp.mkdirp(testDir);
 	t.true(await pathExists(path.join(__dirname, testDir)));
 });
+
+test.serial('mkdirp on directories that already exist', async t => {
+	t.notThrows(ftp.mkdirp(testDir));
+});


### PR DESCRIPTION
Supersedes #8. Fixes #6.

Checks if a directory exists. If it does, then it checks the next directory. If it doesn't, then it switches to creating directories instead of checking for their existence.

Also adds jsftp as a peer dep because it relies on the version of jsftp being at least v1.5.4.

/cc @hasufell